### PR TITLE
fix(security): SECRET_KEY + CORS hardened (CEO Audit Sev-1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Code-Swarm environment template
+# Copy to .env and fill values. NEVER commit a populated .env to git.
+
+# ---- Runtime ----
+ENVIRONMENT=development           # development | staging | production
+CODE_SWARM_BASE_DIR=.
+
+# ---- Security (REQUIRED in production) ----
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(64))"
+SECRET_KEY=
+
+# Comma-separated list. Required when ENVIRONMENT=production.
+# Example: https://app.opensin.ai,https://staging.opensin.ai
+ALLOWED_ORIGINS=
+
+# ---- Persistence (P0 stack) ----
+DATABASE_URL=postgresql://user:pass@localhost:5432/codeswarm
+REDIS_URL=redis://localhost:6379/0
+S3_ENDPOINT=
+S3_BUCKET=code-swarm-artifacts
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+
+# ---- LLM / Gateway ----
+AI_GATEWAY_API_KEY=
+FIREWORKS_API_KEY=
+
+# ---- Simone-MCP ----
+SIMONE_MCP_URL=http://127.0.0.1:8765
+SIMONE_MCP_TOKEN=

--- a/api/main.py
+++ b/api/main.py
@@ -10,6 +10,10 @@ import time
 import asyncio
 from pathlib import Path
 
+import os
+import secrets
+import logging
+
 from auth.security import AuthManager, RBACManager
 # Import monitoring modules directly to avoid circular imports
 from pathlib import Path
@@ -61,8 +65,51 @@ from middleware import RateLimitMiddleware, LoggingMiddleware
 from grpc_server import CodeSwarmServer
 
 
-SECRET_KEY = "code-swarm-secret-key-change-in-production"
-BASE_DIR = Path(".")
+logger = logging.getLogger("code-swarm.api")
+
+# --- Security configuration (CEO Audit fix) -----------------------------------
+# SECRET_KEY MUST be supplied via environment in production. We refuse to start
+# with the legacy hardcoded placeholder. In development, an ephemeral key is
+# generated on boot so local runs still work, but tokens won't survive restarts.
+_LEGACY_INSECURE_KEY = "code-swarm-secret-key-change-in-production"
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development").lower()
+SECRET_KEY = os.getenv("SECRET_KEY", "").strip()
+
+if not SECRET_KEY or SECRET_KEY == _LEGACY_INSECURE_KEY:
+    if ENVIRONMENT == "production":
+        raise RuntimeError(
+            "SECRET_KEY environment variable is required in production "
+            "and must not be the legacy default. Set a strong random value, "
+            "e.g. `python -c 'import secrets; print(secrets.token_urlsafe(64))'`."
+        )
+    SECRET_KEY = secrets.token_urlsafe(64)
+    logger.warning(
+        "SECRET_KEY not set; generated an ephemeral development key. "
+        "Tokens will be invalidated on restart. Set SECRET_KEY in your env "
+        "for stable sessions."
+    )
+
+# CORS: production must declare explicit origins. Wildcard with credentials is
+# rejected by browsers and is a security smell.
+_raw_origins = os.getenv("ALLOWED_ORIGINS", "").strip()
+if _raw_origins:
+    ALLOWED_ORIGINS = [o.strip() for o in _raw_origins.split(",") if o.strip()]
+else:
+    if ENVIRONMENT == "production":
+        raise RuntimeError(
+            "ALLOWED_ORIGINS environment variable is required in production "
+            "(comma-separated list of allowed origins, e.g. https://app.opensin.ai)."
+        )
+    ALLOWED_ORIGINS = [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "http://127.0.0.1:3000",
+    ]
+    logger.warning(
+        "ALLOWED_ORIGINS not set; falling back to localhost development origins."
+    )
+
+BASE_DIR = Path(os.getenv("CODE_SWARM_BASE_DIR", "."))
 
 auth_manager = AuthManager(secret_key=SECRET_KEY, base_dir=BASE_DIR)
 rbac_manager = RBACManager(base_dir=BASE_DIR)
@@ -132,10 +179,10 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
 )
 
 # Add rate limiting and logging middleware


### PR DESCRIPTION
## CEO Audit Severity-1 fixes — top blockers for marketing/release

### Before (on main)
```python
SECRET_KEY = "code-swarm-secret-key-change-in-production"
allow_origins=["*"]; allow_methods=["*"]; allow_headers=["*"]
```

### After
- **SECRET_KEY** is env-driven (`os.getenv("SECRET_KEY")`). Production refuses to start without it; dev generates an ephemeral key with a loud warning. Legacy placeholder is rejected.
- **ALLOWED_ORIGINS** is env-driven (comma-separated). Production refuses to start without it; dev falls back to localhost.
- Wildcard methods/headers replaced with explicit whitelist (`GET/POST/PATCH/DELETE/OPTIONS` and `Authorization/Content-Type/X-Request-ID`).
- `CODE_SWARM_BASE_DIR` configurable via env.
- New `.env.example` documenting all required env vars.

### Why now
The legacy hardcoded secret + wildcard CORS-with-credentials combination was the #1 blocker for any external/marketing release flagged in the CEO audit.

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>