### PR TITLE
chore: add FUNDING.yml (CEO Audit sustainability gate)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# OpenSIN sustainability funding
+# Free MIT code, paid optional support — see /sponsor for the policy.
+
+github: [Delqhi]
+custom:
+  - https://opensin-ai.github.io/Infra-SIN-OpenCode-Stack/sponsor/


### PR DESCRIPTION
Adds GitHub Sponsors metadata so the repo shows the Sponsor button. Free MIT code stays free; sponsor link funds benchmark runs, OCI VM upgrades, and maintainer time. See sponsor policy at https://opensin-ai.github.io/Infra-SIN-OpenCode-Stack/sponsor/

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>